### PR TITLE
[fix] X-Forwarded-For 헤더 추출

### DIFF
--- a/src/main/java/com/pozzle/addit/mvp/controller/MvpQueryController.java
+++ b/src/main/java/com/pozzle/addit/mvp/controller/MvpQueryController.java
@@ -55,7 +55,11 @@ public class MvpQueryController {
         HttpServletRequest request,
         @PathVariable String tickleId
     ) {
-        mvpMetricService.update(request.getRemoteAddr());
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.isEmpty()) {
+            ip = request.getRemoteAddr();
+        }
+        mvpMetricService.update(ip);
         TickleViewResponse response = mvpQueryService.readTickle(tickleId);
         return Response.ok(response);
     }


### PR DESCRIPTION
## 📝작업 내용
- 현재 배포 서버는 GCP의 Nginx를 거쳐 요청을 전달하므로, 프록시의 ip가 아닌 원래의 클라이언트 IP를 추출하기 위해 X-Forwarded-For 헤더를 사용합니다.
